### PR TITLE
Fix authentication session in getTodos API

### DIFF
--- a/pages/api/getTodos.js
+++ b/pages/api/getTodos.js
@@ -2,7 +2,7 @@ import {table, minifyRecords} from "./utils/Airtable";
 import auth0 from "./utils/auth0";
 
 export default auth0.requireAuthentication(async (req, res) => {
-    const {user} = await auth0.getSession();
+    const {user} = await auth0.getSession(req);
     try{
         const records = await table.select({
             filterByFormula: `user_id = '${user.sub}'`


### PR DESCRIPTION
## Summary
- fix missing `req` param when retrieving session in the getTodos API

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68405a70add8832fb73c5f652a27eb61