### PR TITLE
Add Jest tests for getTodos API

### DIFF
--- a/__tests__/getTodos.test.js
+++ b/__tests__/getTodos.test.js
@@ -1,0 +1,43 @@
+import handler from '../pages/api/getTodos';
+import auth0 from '../pages/api/utils/auth0';
+import { table, minifyRecords } from '../pages/api/utils/Airtable';
+
+jest.mock('../pages/api/utils/auth0');
+jest.mock('../pages/api/utils/Airtable');
+
+const mockReq = {};
+const createRes = () => ({ statusCode: 0, json: jest.fn() });
+
+describe('getTodos API', () => {
+  beforeEach(() => {
+    auth0.requireAuthentication.mockImplementation(fn => fn);
+    auth0.getSession.mockResolvedValue({ user: { sub: 'user1' } });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns todos for authenticated user', async () => {
+    const records = [{ id: '1', fields: { title: 'Test' } }];
+    const minified = [{ id: '1', fields: { title: 'Test' } }];
+    table.select.mockReturnValue({ firstPage: jest.fn().mockResolvedValue(records) });
+    minifyRecords.mockReturnValue(minified);
+
+    const res = createRes();
+    await handler(mockReq, res);
+
+    expect(table.select).toHaveBeenCalledWith({ filterByFormula: "user_id = 'user1'" });
+    expect(res.statusCode).toBe(200);
+    expect(res.json).toHaveBeenCalledWith(minified);
+  });
+
+  it('handles errors from Airtable', async () => {
+    table.select.mockReturnValue({ firstPage: jest.fn().mockRejectedValue(new Error('bad')) });
+    const res = createRes();
+    await handler(mockReq, res);
+
+    expect(res.statusCode).toBe(500);
+    expect(res.json).toHaveBeenCalledWith({ msg: 'Something went wrong' });
+  });
+});

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['next/babel']
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]sx?$': 'babel-jest'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test": "jest"
   },
   "dependencies": {
     "@auth0/nextjs-auth0": "^0.16.0",
@@ -17,6 +18,10 @@
   "devDependencies": {
     "postcss": "^8.2.4",
     "postcss-preset-env": "^6.7.0",
-    "tailwindcss": "^2.0.2"
+    "tailwindcss": "^2.0.2",
+    "jest": "^29.0.0",
+    "babel-jest": "^29.0.0",
+    "@babel/core": "^7.0.0",
+    "@babel/preset-env": "^7.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- set up Jest with `babel-jest`
- add configuration files
- provide a unit test for `/api/getTodos`
- add `npm test` script

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405c66032c832facfc1b3506b39a02