### PR TITLE
Fix font weight and focus style in TodoForm

### DIFF
--- a/components/TodoForm.js
+++ b/components/TodoForm.js
@@ -15,9 +15,9 @@ export default function TodoForm({user}){
     return (
         <form className="form my-6" onSubmit={handleSubmit}>
             <div className="flex flex-col text-sm mb-2">
-                <label className="font-bolc mb-2 text-gray-800" htmlFor="todo">Todo</label>
+                <label className="font-bold mb-2 text-gray-800" htmlFor="todo">Todo</label>
                 <input type="text" name="todo" id="todo" value={todo} onChange={(e) => setTodo(e.target.value)}
-                       placeholder="Learn about authentication" className="border border-gray-200 p-2 rounded-lg appearance-none focus-outline-none focus:border-gray-500"/>
+                       placeholder="Learn about authentication" className="border border-gray-200 p-2 rounded-lg appearance-none focus:outline-none focus:border-gray-500"/>
             </div>
             <button type="submit" className="w-full rounded bg-blue-500 hover:bg-blue-600 text-white py-2 px-4">Submit</button>
         </form>


### PR DESCRIPTION
## Summary
- correct typos in TodoForm component
- ensure file ends with newline

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68406010a6e8832fb2863531cdd21d64