### PR TITLE
Fix NavBar color class typo

### DIFF
--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -3,7 +3,7 @@ import React from "react"
 export default function NavBar({user}){
     return (
         <nav className="flex justify-between items-center py-4">
-            <p className="text-2xl font-bold text-grey-800">My Todos</p>
+            <p className="text-2xl font-bold text-gray-800">My Todos</p>
             <div className="flex">
                 {user && (
                     <a href="/api/logout" className="rounded bg-blue-500 hover:bg-blue-600 text-white py-2 px-4">


### PR DESCRIPTION
## Summary
- correct grey/gray color class in `NavBar`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684060165188832f9f6733a8d7284a1f