### PR TITLE
Update Node.js version in build workflow

### DIFF
--- a/.github/workflows/build-pr-main.yml
+++ b/.github/workflows/build-pr-main.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '16'
           cache: 'npm'
       - name: Install dependencies
         run: npm ci
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '16'
           cache: 'npm'
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
- use Node.js 16 in build-pr-main workflow

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406721a848832fbc60933bd9899214